### PR TITLE
Update run_lab5.sh

### DIFF
--- a/lab5/starter/tools/run_lab5.sh
+++ b/lab5/starter/tools/run_lab5.sh
@@ -6,7 +6,7 @@
 # Usage      : Name your producer executable as "produce" and put it in the
 #              same directory where you put this shell script.
 #              Type
-#              ./run_lab5.sh 
+#              sh run_lab5.sh or bash run_lab5.sh
 #             
 # Course Name: ECE254 Operating Systems and System Programming
 # Description: Lab5 utility - extracting timing info.


### PR DESCRIPTION
./run_lab5.sh gives permission error. For students running this on ecelinux, shouldn't this say bash or sh be more appropriate?
